### PR TITLE
Support subdomains

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -7,6 +7,7 @@ spl_autoload_register(function ($class_name) {
         "Casauth" => "$basedir/casauth_pi.php",
         "Casauth_attributes" => "$basedir/casauth_attributes.php",
         "Casauth_model" => "$basedir/casauth_model.php",
+        "Casauth_utils" => "$basedir/casauth_utils.php",
         "Casauth_Exception" => "$basedir/casauth_exception.php"
     );
     if(isset($class_map[$class_name])) {

--- a/casauth_pi.php
+++ b/casauth_pi.php
@@ -431,9 +431,18 @@ class Casauth {
         phpCAS::setDebug();
         phpCAS::setVerbose(true);
         phpCAS::client(CAS_VERSION_2_0, $this->config['cas_host'], (int)$this->config['cas_port'], $this->config['cas_context']);
+
+        $service_url = null;
         if($this->config['cas_service_url']) {
-            phpCAS::setFixedServiceURL($this->config['cas_service_url']);
+            $service_url = $this->config['cas_service_url'];
+        } else if(getenv('SCALAR_CASAUTH_SERVICE_URL')) {
+            $service_url = getenv('SCALAR_CASAUTH_SERVICE_URL');
         }
+
+        if($service_url) {
+            phpCAS::setFixedServiceURL($service_url);
+        }
+
         phpCAS::setNoCasServerValidation(); // TODO: Fix this for production
 
         if(isset($this->config['cas_debug'])) {

--- a/casauth_utils.php
+++ b/casauth_utils.php
@@ -1,0 +1,51 @@
+<?php
+
+class Casauth_utils {
+
+    /**
+     * Checks if one URL is a subdomain of another.
+     *
+     * @param $child_url subdomain url
+     * @param $parent_url parent domain url
+     * @return bool
+     */
+    public static function is_subdomain($child_url, $parent_url) {
+        $parsed_child = parse_url($child_url);
+        $parsed_parent = parse_url($parent_url);
+        if(!isset($parsed_child['host']) || !isset($parsed_parent['host'])) {
+            return false;
+        }
+
+        $child_host = $parsed_child['host'];
+        $parent_host = $parsed_parent['host'];
+        if(strlen($child_host) > strlen($parent_host) && ".$parent_host" == substr($child_host, strlen($child_host) - strlen($parent_host) - 1)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Replaces the hostname part of the login base url.
+     *
+     * A scalar session typically maps the login base_url to logged-in user object,
+     * so in order to ensure a user is "logged in" on a subdomain, it's necessary
+     * to set the appropriate login_basename containing the subdomain host.
+     *
+     * This function is intended to be used to swap out the "host" part of the
+     * login base_url from the parent domain to provide a valid login_basename
+     * for that subdomain.
+     *
+     * @param $login_basename base URL of scalar system
+     * @param $subdomain_host the subdomain host
+     * @return string the base URL with the host replaced
+     */
+    public static function subdomain_login_basename($login_basename, $subdomain_host) {
+        $parsed_login_basename = parse_url($login_basename);
+        $scheme = isset($parsed_login_basename['scheme']) ? $parsed_login_basename['scheme'].'://' : 'http://';
+        $host = isset($subdomain_host) ? $subdomain_host : 'localhost';
+        $port = isset($parsed_login_basename['port']) ? ':'.$parsed_login_basename['port'] : '';
+        $path = isset($parsed_login_basename['path']) ? $parsed_login_basename['path'] : '/';
+        return $scheme.$host.$port.$path;
+    }
+}

--- a/config.ini.sample
+++ b/config.ini.sample
@@ -2,3 +2,4 @@ cas_host = "localhost"
 cas_port = 3004
 cas_context = "/cas"
 cas_button_text = "Login with CAS Server"
+cas_service_url = "http://localhost/system/login?state=cas"

--- a/tests/CasauthTest.php
+++ b/tests/CasauthTest.php
@@ -56,7 +56,7 @@ class CasauthTest extends TestCase {
     }
 
     public function testUserPreauthorized() {
-        $test_user_record = array('user_id'=>1,'email'=>'somebody@local.domain');
+        $test_user_record = array('user_id' => 1, 'email' => 'somebody@local.domain');
         $tests = array(
             array(
                 'find_by_cas_id' => true,
@@ -95,7 +95,7 @@ class CasauthTest extends TestCase {
             ),
         );
 
-        foreach($tests as $test) {
+        foreach ($tests as $test) {
             $model_stub = $this->createMock('Mock_Casauth_model');
             $model_stub->method('find_by_cas_id')->willReturn($test['find_by_cas_id']);
             $user_stub = $this->createMock('Mock_User_model');

--- a/tests/Casauth_utilsTest.php
+++ b/tests/Casauth_utilsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class Casauth_utilsTest extends TestCase {
+
+    public function testIsSubdomain() {
+        $tests = array(
+            array(
+                'parent_url' => 'http://scalar.localdomain/',
+                'child_url' => 'http://scalar.localdomain/',
+                'expected' => false,
+            ),
+            array(
+                'parent_url' => 'http://scalar.localdomain/',
+                'child_url' => 'http://foo.scalar.localdomain/',
+                'expected' => true,
+            ),
+            array(
+                'parent_url' => 'http://scalar.localdomain/',
+                'child_url' => 'http://bar.scalar.localdomain/',
+                'expected' => true,
+            ),
+            array(
+                'parent_url' => 'http://scalar.localdomain/',
+                'child_url' => 'http://anotherscalar.localdomain/',
+                'expected' => false,
+            ),
+            array(
+                'parent_url' => 'http://scalar.localdomain/',
+                'child_url' => '/',
+                'expected' => false
+            ),
+            array(
+                'parent_url' => '/',
+                'child_url' => 'http://scalar.localdomain/',
+                'expected' => false
+            )
+        );
+        foreach ($tests as $test) {
+            $this->assertEquals($test['expected'], Casauth_utils::is_subdomain($test['child_url'], $test['parent_url']));
+        }
+    }
+
+    public function testSubdomainLoginUrl() {
+        $tests = array(
+            array(
+                'login_basename' => 'http://scalar.localdomain/',
+                'redirect_url' => 'http://foo.scalar.localdomain/index',
+                'expected' => 'http://foo.scalar.localdomain/'
+            ),
+            array(
+                'login_basename' => 'http://scalar.localdomain/',
+                'redirect_url' => 'http://bar.scalar.localdomain/index',
+                'expected' => 'http://bar.scalar.localdomain/'
+            ),
+            array(
+                'login_basename' => 'http://scalar.localdomain/',
+                'redirect_url' => 'http://scalar.localdomain/foo/index',
+                'expected' => 'http://scalar.localdomain/',
+            ),
+        );
+
+        foreach ($tests as $test) {
+            $redirect_host = parse_url($test['redirect_url'], PHP_URL_HOST);
+            $url = Casauth_utils::subdomain_login_basename($test['login_basename'], $redirect_host);
+            $this->assertEquals($test['expected'], $url);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for custom subdomains. 

Since the CAS server will only return the user to the parent domain (e.g. the `service_url`), we need to be sure to key the session data for the subdomain, otherwise the scalar will not consider the user "logged in" on that domain. This also depends on the `cookie_domain` being configured domain-wide.

@ColeDCrawford @dodget 