### PR TITLE
Check if the index is set before invoking it

### DIFF
--- a/casauth_pi.php
+++ b/casauth_pi.php
@@ -433,7 +433,7 @@ class Casauth {
         phpCAS::client(CAS_VERSION_2_0, $this->config['cas_host'], (int)$this->config['cas_port'], $this->config['cas_context']);
 
         $service_url = null;
-        if($this->config['cas_service_url']) {
+        if(isset($this->config['cas_service_url'])) {
             $service_url = $this->config['cas_service_url'];
         } else if(getenv('SCALAR_CASAUTH_SERVICE_URL')) {
             $service_url = getenv('SCALAR_CASAUTH_SERVICE_URL');


### PR DESCRIPTION
This PR resolves a small bug.
- Wrap `$this->config['cas_service_url']` in `isset` when checking it in `if` statement